### PR TITLE
replace td valign attribute by a css vertical-align

### DIFF
--- a/src/PivotTableUI.jsx
+++ b/src/PivotTableUI.jsx
@@ -310,8 +310,7 @@ class PivotTableUI extends React.PureComponent {
                     !this.props.hiddenFromDragDrop.includes(e));
         const rowAttrsCell = this.makeDnDCell(rowAttrs, this.propUpdater('rows'),
             'pvtAxisContainer pvtVertList pvtRows');
-
-        const outputCell = <td valign="top">
+        const outputCell = <td className="pvtOutput">
             <PivotTable {...update(this.props, {data: {$set: this.materializedInput}})} />
         </td>;
 

--- a/src/pivottable.css
+++ b/src/pivottable.css
@@ -11,6 +11,10 @@
     -ms-user-select: none;
 }
 
+.pvtUi td.pvtOutput {
+    vertical-align: top;
+}
+
 table.pvtTable {
     font-size: 8pt;
     text-align: left;


### PR DESCRIPTION
`valign` has been deprecated since html 4.0: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#attr-valign

Note: create-react-app settings (in dev mode, so not really an issue) is complaining about it:
![image](https://user-images.githubusercontent.com/168223/32694887-37840fce-c71a-11e7-97c7-c3725d3412f6.png)
