### PR TITLE
Export UI classes to allow reuse.

### DIFF
--- a/src/PivotTableUI.jsx
+++ b/src/PivotTableUI.jsx
@@ -9,7 +9,7 @@ import Draggable from 'react-draggable';
 /* eslint-disable react/prop-types */
 // eslint can't see inherited propTypes!
 
-class DraggableAttribute extends React.Component {
+export class DraggableAttribute extends React.Component {
   constructor(props) {
     super(props);
     this.state = {open: false, top: 0, left: 0, filterText: ''};
@@ -187,7 +187,7 @@ DraggableAttribute.propTypes = {
   zIndex: PropTypes.number,
 };
 
-class Dropdown extends React.PureComponent {
+export class Dropdown extends React.PureComponent {
   render() {
     return (
       <div className="pvtDropdown" style={{zIndex: this.props.zIndex}}>


### PR DESCRIPTION
I'd like to make a custom filter box that is tailored to my app. Since React Pivottable is nicely structured, this would be possible by just overriding `getFilterBox()` of `DraggableAttribute` once `DraggableAttribute` is exported. Therefore, IMO it would be useful to export the UI classes to allow overriding their behaviour (without changing the default behaviour).