### PR TITLE
Expose aggregator outlet to allow rendering additional content in aggregatorCell

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:jest": "jest",
     "test": "npm run test:eslint && npm run test:prettier && npm run test:jest",
     "clean": "rm -rf __tests__ PivotTable.js* PivotTableUI.js* PlotlyRenderers.js* TableRenderers.js* Utilities.js* pivottable.css",
-    "doPublish": "npm run clean && cp src/pivottable.css . && babel src --out-dir=. --source-maps --presets=env,react --plugins babel-plugin-add-module-exports && npm publish",
+    "build": "npm run clean && cp src/pivottable.css . && babel src --out-dir=. --source-maps --presets=env,react --plugins babel-plugin-add-module-exports",
+    "doPublish": "npm run build && npm publish",
     "postpublish": "npm run clean",
     "deploy": "webpack -p && mv bundle.js examples && cd examples && git init && git add . && git commit -m build && git push --force git@github.com:plotly/react-pivottable.git master:gh-pages && rm -rf .git bundle.js"
   },

--- a/src/PivotTableUI.jsx
+++ b/src/PivotTableUI.jsx
@@ -375,9 +375,9 @@ class PivotTableUI extends React.PureComponent {
     const numValsAllowed =
       this.props.aggregators[this.props.aggregatorName]([])().numInputs || 0;
 
-    const aggregatorControls = this.props.aggregators[
+    const aggregatorCellOutlet = this.props.aggregators[
       this.props.aggregatorName
-    ]([])().controls;
+    ]([])().outlet;
 
     const rendererName =
       this.props.rendererName in this.props.renderers
@@ -472,7 +472,7 @@ class PivotTableUI extends React.PureComponent {
           />,
           i + 1 !== numValsAllowed ? <br key={`br${i}`} /> : null,
         ])}
-        {aggregatorControls && aggregatorControls(this.props.data)}
+        {aggregatorCellOutlet && aggregatorCellOutlet(this.props.data)}
       </td>
     );
 

--- a/src/PivotTableUI.jsx
+++ b/src/PivotTableUI.jsx
@@ -375,6 +375,10 @@ class PivotTableUI extends React.PureComponent {
     const numValsAllowed =
       this.props.aggregators[this.props.aggregatorName]([])().numInputs || 0;
 
+    const aggregatorControls = this.props.aggregators[
+      this.props.aggregatorName
+    ]([])().controls;
+
     const rendererName =
       this.props.rendererName in this.props.renderers
         ? this.props.rendererName
@@ -468,6 +472,7 @@ class PivotTableUI extends React.PureComponent {
           />,
           i + 1 !== numValsAllowed ? <br key={`br${i}`} /> : null,
         ])}
+        {aggregatorControls && aggregatorControls(this.props.data)}
       </td>
     );
 


### PR DESCRIPTION
This PR introduces an additional key on aggregators, `outlet`, a function which, if present, gets called once by `PivotTableUI` to render additional aggregator-specific content just below the built-in aggregator selector (in the area outlined in red here):

<img width="800" alt="Screen Shot 2020-10-19 at 11 50 34 AM" src="https://user-images.githubusercontent.com/1994207/96475638-40b88080-1202-11eb-9e27-697893b3dfda.png">

Some use cases for providing this escape hatch include:
* rendering aggregator-specific custom UI controls
* rendering aggregate stats that you want visible regardless of the state of the pivottable attributes

When the outlet function is called, it will be passed the `PivotTableUI`'s `props.data`, in case the called aggregator wants to make use of that data.

Here's a kind of silly example of a custom aggregator using this new function:

```js
  function customCount(formatter) {
    return () => 
      function() {
        return {
          count: 0,
          push() {
            this.count++;
          },
          value() {
            return this.count;
          },
          format: formatter,
          outlet: (records) => {
            return (
              <div>There are ${records.length} records total</div>
            );
          },
        };
      };
    };
  },
```

Resolves #117 