### PR TITLE
Use CSS child selectors for standard table tags to better isolate styles

### DIFF
--- a/src/pivottable.css
+++ b/src/pivottable.css
@@ -23,8 +23,8 @@ table.pvtTable {
     margin-left: 3px;
     font-family: Verdana;
 }
-table.pvtTable thead tr th,
-table.pvtTable tbody tr th {
+table.pvtTable > thead > tr > th,
+table.pvtTable > tbody > tr > th {
     background-color: #ebf0f8;
     border: 1px solid #c8d4e3;
     font-size: 8pt;
@@ -38,7 +38,7 @@ table.pvtTable .pvtTotalLabel {
     text-align: right;
 }
 
-table.pvtTable tbody tr td {
+table.pvtTable > tbody > tr > td {
     color: #2a3f5f;
     padding: 5px;
     background-color: #fff;


### PR DESCRIPTION
I have a custom aggregator that renders a table within the default Table renderer's cell. Currently some of the table styling is cascading to this nested table. This PR switches to CSS child selectors (`>`) for the few styles that aren't isolated by a class name, to prevent cascading to nested tables.