### PR TITLE
Issue #109: fixing an error with totals and more than 2 attr.

### DIFF
--- a/src/Utilities.js
+++ b/src/Utilities.js
@@ -581,6 +581,9 @@ class PivotData {
         }
         for (const k in criteria) {
           const v = criteria[k];
+          if (v === undefined){
+            continue;
+          }
           if (v !== (k in record ? record[k] : 'null')) {
             return;
           }


### PR DESCRIPTION
When using 2 attributes or more on one side, the totals for the row/column are incorrect. This fixes the issue by skipping undefined filters  